### PR TITLE
Add Version sub-command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,27 @@
+OUTPUT=deskctl
+#Version variables
+VERSION?=dev
+GOMODULE=github.com/tzermias/deskcli
+COMMIT?=$(shell git rev-parse --short HEAD 2>/dev/null || echo "unknown")
+BUILD_TIME?=$(shell date -u +"%Y-%m-%dT%H:%M:%SZ")
+LDFLAGS=-ldflags "-X $(GOMODULE)/cmd.Version=$(VERSION) -X $(GOMODULE)/cmd.Commit=$(COMMIT) -X $(GOMODULE)/cmd.BuildTime=$(BUILD_TIME)"
+
+
+make-deps:
+	go mod download
+	go mod tidy
+
+test: make-deps
+	go test
+
+fmt:
+	gofmt -s -w .
+vet:
+	go vet ./...
+
+build: fmt vet test
+	go build $(LDFLAGS) -o bin/$(OUTPUT) -v ./
+
+clean:
+	go clean 
+	rm -rf dist/ bin/

--- a/Makefile
+++ b/Makefile
@@ -1,17 +1,17 @@
 OUTPUT=deskctl
 #Version variables
 VERSION?=dev
-GOMODULE=github.com/tzermias/deskcli
+GOMODULE=github.com/tzermias/deskctl
 COMMIT?=$(shell git rev-parse --short HEAD 2>/dev/null || echo "unknown")
 BUILD_TIME?=$(shell date -u +"%Y-%m-%dT%H:%M:%SZ")
 LDFLAGS=-ldflags "-X $(GOMODULE)/cmd.Version=$(VERSION) -X $(GOMODULE)/cmd.Commit=$(COMMIT) -X $(GOMODULE)/cmd.BuildTime=$(BUILD_TIME)"
 
 
-make-deps:
+deps:
 	go mod download
 	go mod tidy
 
-test: make-deps
+test: deps
 	go test
 
 fmt:

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A CLI tool to manage Bluetooth standing desks.
 Currently limited to Jiecang standing desks
 
 Tool is based on findings from [phord/Jarvis](https://github.com/phord/Jarvis) and [pimp-my-desk/desk-control](https://gitlab.com/pimp-my-desk/desk-control) where most UART commands were found.
-`deskcli` just establishes a Bluetooth connection to the desk and issues respective commands. That's it.
+`deskctl` just establishes a Bluetooth connection to the desk and issues respective commands. That's it.
 
 The tool is under development and only a small subset of features (moving the desk to memory presets) is supported at the moment.
 

--- a/cmd/gotoMemory.go
+++ b/cmd/gotoMemory.go
@@ -9,7 +9,7 @@ import (
 	"strconv"
 
 	"github.com/spf13/cobra"
-	"github.com/tzermias/deskcli/pkg/jiecang"
+	"github.com/tzermias/deskctl/pkg/jiecang"
 	"tinygo.org/x/bluetooth"
 )
 

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -1,0 +1,38 @@
+/*
+Copyright © 2025 Aris Tzermias
+*/
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+var (
+	Version   = "dev"
+	Commit    = "unknown"
+	BuildTime = "unknown"
+)
+
+var versionCmd = &cobra.Command{
+	Use:   "version",
+	Short: "Show deskctl version",
+	Run: func(cmd *cobra.Command, args []string) {
+		fmt.Printf("Version: %s (%s)\nBuild Date: %s\n", Version, Commit, BuildTime)
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(versionCmd)
+
+	// Here you will define your flags and configuration settings.
+
+	// Cobra supports Persistent Flags which will work for this command
+	// and all subcommands, e.g.:
+	// versionCmd.PersistentFlags().String("foo", "", "A help for foo")
+
+	// Cobra supports local flags which will only run when this command
+	// is called directly, e.g.:
+	// versionCmd.Flags().BoolP("toggle", "t", false, "Help message for toggle")
+}

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/tzermias/deskcli
+module github.com/tzermias/deskctl
 
 go 1.22.2
 

--- a/hack/test.go
+++ b/hack/test.go
@@ -4,7 +4,7 @@ import (
 	"log"
 	"time"
 
-	"github.com/tzermias/deskcli/pkg/jiecang"
+	"github.com/tzermias/deskctl/pkg/jiecang"
 	"tinygo.org/x/bluetooth"
 )
 

--- a/main.go
+++ b/main.go
@@ -1,10 +1,9 @@
 /*
 Copyright © 2025 Aris Tzermias
-
 */
 package main
 
-import "github.com/tzermias/deskcli/cmd"
+import "github.com/tzermias/deskctl/cmd"
 
 func main() {
 	cmd.Execute()


### PR DESCRIPTION
This PR adds `version` command along with a Makefile to  build deskctl.
Version information is injected using linker flags (-ldflags).

Moreover this PR fixes a regression where the main package had an incorrect name (`deskcli` instead of `deskctl`)