### PR TITLE
Add inline height display during movement operations

### DIFF
--- a/pkg/jiecang/height.go
+++ b/pkg/jiecang/height.go
@@ -69,6 +69,7 @@ func (j *Jiecang) GoToHeight(ctx context.Context, height uint8) error {
 		j.mu.RUnlock()
 
 		if currentHeight == height {
+			fmt.Printf("\rHeight: %d cm\n", currentHeight)
 			break
 		}
 
@@ -78,9 +79,10 @@ func (j *Jiecang) GoToHeight(ctx context.Context, height uint8) error {
 			if err := j.sendCommand(commands["stop"]); err != nil {
 				return fmt.Errorf("failed to send stop command: %w", err)
 			}
-			fmt.Printf("Operation cancelled at height %d cm\n", currentHeight)
+			fmt.Printf("\nOperation cancelled at height %d cm\n", currentHeight)
 			return nil
 		case <-ticker.C:
+			fmt.Printf("\rHeight: %d cm", currentHeight)
 			if err := j.sendCommand(command); err != nil {
 				return fmt.Errorf("failed to send goto command: %w", err)
 			}

--- a/pkg/jiecang/memory.go
+++ b/pkg/jiecang/memory.go
@@ -51,15 +51,16 @@ func (j *Jiecang) GoToMemory(ctx context.Context, memoryNum int) error {
 		j.mu.RUnlock()
 
 		if currentHeight == targetHeight {
+			fmt.Printf("\rHeight: %d cm\n", currentHeight)
 			break
 		}
 
 		select {
 		case <-ctx.Done():
-			// Context cancelled, return
-			fmt.Printf("Operation cancelled at height %d cm\n", currentHeight)
+			fmt.Printf("\nOperation cancelled at height %d cm\n", currentHeight)
 			return nil
 		case <-ticker.C:
+			fmt.Printf("\rHeight: %d cm", currentHeight)
 			if err := j.sendCommand(commands[commandKey]); err != nil {
 				return fmt.Errorf("failed to send goto memory%d command: %w", memoryNum, err)
 			}


### PR DESCRIPTION
## Summary

Adds real-time height feedback to `goto-height` and `goto-memory` commands.
The current height is printed inline every 200ms, overwriting the same
terminal line, so users can see the desk moving in real time.

## Output

```
$ deskctl goto-height 100
Height: 78 cm
Height: 85 cm
Height: 92 cm
Height: 100 cm
```

Each line overwrites the previous one via `\r`. On context cancellation
(Ctrl+C) the line is terminated with `\n` before the cancellation message.

## Changes

- `pkg/jiecang/height.go`: print `\rHeight: X cm` on each 200ms tick
  inside `GoToHeight()`
- `pkg/jiecang/memory.go`: same pattern inside `GoToMemory()`

No new dependencies, no API signature changes, no new types.

## Test Plan

- [x] All tests pass (`make test`)
- [x] Code formatted (`make fmt`)
- [x] Static analysis clean (`make vet`)
- [x] Binary builds successfully (`make build`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)